### PR TITLE
[Bug-Fix] Fixed class name capitalization for `penisrem` and `whois` cogs.

### DIFF
--- a/penisrem/info.json
+++ b/penisrem/info.json
@@ -4,7 +4,7 @@
     "SHORT" : "Totally accurate penis size calculator",
     "DESCRIPTION" : "Tells you a user's penis size",
     "DISABLED" : false,
-    "NAME" : "penis",
+    "NAME" : "PenisRem",
     "TAGS" : ["user", "random"],
     "INSTALL_MSG" : "Usage: `[p]penis <user>` \n If you are the bot's owner, your penis is huge!"
 }

--- a/whois/Info.json
+++ b/whois/Info.json
@@ -4,7 +4,7 @@
     "SHORT" : "Calls information on a user",
     "DESCRIPTION" : "Call a user's information",
     "DISABLED" : false,
-    "NAME" : "whois",
+    "NAME" : "Whois",
     "TAGS" : ["user", "random"],
     "INSTALL_MSG" : "Usage: `[p]whois <user>` ABSOLUTLEY WILL NOT WORK if you don't have economy loaded"
 }


### PR DESCRIPTION
See issue #6 for bug.